### PR TITLE
(fix): Export variables from entrypoint.sh and multiple chaos action support in a single github job  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ RUN apt-get update && apt-get install -y git && \
     apt-get install -y ssh && \
     apt install ssh rsync
 
-RUN export GOPATH=$HOME/go
-RUN export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
-
 COPY README.md /
 COPY entrypoint.sh /entrypoint.sh
 COPY experiments ./experiments

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ LABEL com.github.actions.description="Different Chaos Experiment for Kubernetes"
 LABEL com.github.actions.icon="terminal"
 LABEL com.github.actions.color="blue"
 
+ENV GOPATH=/github/home/go
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+
 ARG KUBECTL_VERSION=1.17.0
 ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,16 +8,17 @@ echo "$KUBE_CONFIG_DATA" | base64 --decode > ${HOME}/.kube/config
 export KUBECONFIG=${HOME}/.kube/config
 
 ##Setup 
-export GOPATH=$HOME/go
-export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 mkdir -p $HOME/go/src/github.com/mayadata-io
-rsync -az --delete ${GOPATH}/src/github.com/mayadata-io/
 cd ${GOPATH}/src/github.com/mayadata-io/
+dir=${GOPATH}/src/github.com/mayadata-io/chaos-ci-lib
+if [ ! -d $dir ]
+then
 git clone https://github.com/mayadata-io/chaos-ci-lib.git
+fi
 cd chaos-ci-lib
 
 ##Install litmus if it is not already installed
-if [ $INSTALL_LITMUS = true ]
+if [ "$INSTALL_LITMUS" = "true" ]
 then
   go test tests/install-litmus_test.go -v -count=1
 fi
@@ -26,7 +27,7 @@ fi
 go test tests/${EXPERIMENT_NAME}_test.go -v -count=1
 
 ##litmus cleanup
-if [ $LITMUS_CLEANUP = true ]
+if [ "$LITMUS_CLEANUP" = "true" ]
 then
   go test tests/uninstall-litmus_test.go -v -count=1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,8 @@ echo "$KUBE_CONFIG_DATA" | base64 --decode > ${HOME}/.kube/config
 export KUBECONFIG=${HOME}/.kube/config
 
 ##Setup 
+export GOPATH=$HOME/go
+export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 mkdir -p $HOME/go/src/github.com/mayadata-io
 rsync -az --delete ${GOPATH}/src/github.com/mayadata-io/
 cd ${GOPATH}/src/github.com/mayadata-io/

--- a/experiments/pod-network-latency/README.md
+++ b/experiments/pod-network-latency/README.md
@@ -39,7 +39,7 @@ jobs:
         TARGET_CONTAINER: nginx
         TOTAL_CHAOS_DURATION: 60
         NETWORK_INTERFACE: eth0
-      	NETWORK_LATENCY: 60000
+        NETWORK_LATENCY: 60000
         ##Select true if you want to uninstall litmus after chaos
         LITMUS_CLEANUP: true        
 ```


### PR DESCRIPTION
- This PR is to export the variables from entrypoint.sh
- Add support for multiple chaos action runs in a single gtihub job

Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>