### PR TITLE
chore(actions): Add verison v0.1.0 and remove extra commands form readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ There is a number of chaos experiments that can be performed using `github-chaos
 
 We just need  to follow these simple steps to run a chaos experiment using this action:
 
-- **Install Litmus**: Before running any experiment we need to setup litmus in the cluster. If litmus is not already installed then we can install it from `github-chaos-action` by just passing an ENV `INSTALL-LITMUS` with `true` value. This will bring up litmus with all infra components running in litmus namespace.
+- **Deploy Application**: We need to have an application running on which the chaos will be performed. The user has to create an application and pass the application details through action's ENV. The details involved application kind (deployment,statefulset,daemonset), application label, and namespace.
 
-- **Deploy Application**: After having litmus installed in the cluster we need to have an application running on which the chaos will be performed. The user has to create an application and pass the application details through action's ENV. The details involved application kind (deployment,statefulset,daemonset), application label, and namespace.
+- **Install Litmus**: Before running any experiment we need to setup litmus in the cluster. If litmus is not already installed then we can install it from `github-chaos-action` by just passing an ENV `INSTALL-LITMUS` with `true` value. This will bring up litmus with all infra components running in litmus namespace.
 
 - **Select experiment**: Select an experiment from the list of experiments mentioned in the below section which you want to perform on an application. Get the details of the experiment and how to run the actions for a particular experiment.
 
@@ -59,12 +59,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running Litmus pod delete chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         ##Pass kubeconfig data from secret in base 64 encoded form 
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}

--- a/experiments/container-kill/README.md
+++ b/experiments/container-kill/README.md
@@ -20,11 +20,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    - uses: actions/checkout@master
       
     - name: Running container kill chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/disk-fill/README.md
+++ b/experiments/disk-fill/README.md
@@ -22,12 +22,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running disk-fill chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/node-cpu-hog/README.md
+++ b/experiments/node-cpu-hog/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running node-cpu-hog chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/node-memory-hog/README.md
+++ b/experiments/node-memory-hog/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running node-memory-hog chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##if litmus is not installed

--- a/experiments/pod-cpu-hog/README.md
+++ b/experiments/pod-cpu-hog/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running pod-cpu-hog chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/pod-delete/README.md
+++ b/experiments/pod-delete/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
-      
+          
     - name: Running pod delete chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/pod-memory-hog/README.md
+++ b/experiments/pod-memory-hog/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running pod-memory-hog chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/pod-network-corruption/README.md
+++ b/experiments/pod-network-corruption/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running pod network corruption chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed

--- a/experiments/pod-network-latency/README.md
+++ b/experiments/pod-network-latency/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
       
     - name: Running pod-network-latency chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         #If litmus is not installed

--- a/experiments/pod-network-loss/README.md
+++ b/experiments/pod-network-loss/README.md
@@ -19,12 +19,9 @@ jobs:
   build:
     
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@master
-      
+    
     - name: Running pod-network-loss chaos experiment
-      uses: mayadata-io/github-chaos-actions@master
+      uses: mayadata-io/github-chaos-actions@v0.1.0
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ##If litmus is not installed


### PR DESCRIPTION
- This PR is for adding version v0.1.0 in the README files to run different chaos actions. Currently, it is set to `master` that is running the code from the master branch and master branch will keep updating so better to point it to a specific version that is v0.1.0 for now.
- Removing extra commands (like mentioned below) which checkout the codes. It is not a part of our implementation and it will work without doing a checkout so better to remove it from README.

```yaml
    steps:	
    - uses: actions/checkout@master
```

Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>