### PR TITLE
Fix/oci cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN chmod +x /usr/local/bin/kubectl
 RUN apt-get update && apt-get install -y git \
     curl \
     unzip \
-    python3-pip \
+    pipx \
     && apt-get clean
 
 RUN apt-get update && \
@@ -35,7 +35,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     unzip awscliv2.zip && \
     ./aws/install
 
-RUN pip install oci-cli
+RUN pipx install oci-cli==3.29.0
 
 COPY README.md /
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,8 +45,12 @@ if [ "$EXPERIMENT_NAME" == "all" ]; then
   cd ..
 
 elif [ ! -z "$EXPERIMENT_NAME" ]; then
-## Run the selected chaos experiment
-  go test experiments/${EXPERIMENT_NAME}_test.go -v -count=1 -timeout=${TEST_TIMEOUT}s
+## Run the selected chaos experiment(s)
+  IFS=' ' read -r -a experiments <<< "$EXPERIMENT_NAME"
+  for experiment in "${experiments[@]}"
+  do
+    go test experiments/"${experiment}"_test.go -v -count=1 -timeout=${TEST_TIMEOUT}s
+  done
 fi
 
 ##litmus cleanup

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ fi
 
 if [ ! -d $dir ]
 then
-  git clone https://github.com/litmuschaos/chaos-ci-lib.git
+  git clone https://github.com/merkata/chaos-ci-lib.git
 fi
 cd chaos-ci-lib
 


### PR DESCRIPTION
Installing `oci-cli` now fails with

```text
Step 21/26 : RUN pip install oci-cli
   ---> Running in 71fd401c244a
  error: externally-managed-environment
  
  × This environment is externally managed
  ╰─> To install Python packages system-wide, try apt install
      python3-xyz, where xyz is the package you are trying to
      install.
      
      If you wish to install a non-Debian-packaged Python package,
      create a virtual environment using python3 -m venv path/to/venv.
      Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
      sure you have python3-full installed.
      
      If you wish to install a non-Debian packaged Python application,
      it may be easiest to use pipx install xyz, which will manage a
      virtual environment for you. Make sure you have pipx installed.
```

This fix follows the recommendation and installs the python package via `pipx`. Tested in a forked repo.